### PR TITLE
fix: wrong form for multiple pronouns

### DIFF
--- a/src/main/kotlin/me/owdding/skyblockpv/widgets/PronounWidget.kt
+++ b/src/main/kotlin/me/owdding/skyblockpv/widgets/PronounWidget.kt
@@ -20,7 +20,7 @@ object PronounWidget {
                 val display = when (pronouns.size) {
                     0 -> return@completableDisplay Displays.empty()
                     1 -> "${pronouns.first().first}/${pronouns.first().second}"
-                    else -> pronouns.fold("") { acc, set -> if (acc.isEmpty()) set.first else "$acc/${set.second}" }
+                    else -> pronouns.fold("") { acc, set -> if (acc.isEmpty()) set.first else "$acc/${set.first}" }
                 }
                 val shader = PronounDbDecorations.getShader(decoration ?: "")
                 ExtraDisplays.component(


### PR DESCRIPTION
Fixed the wrong form being used when a player has multiple pronouns.

Examples:
* `["she"]`: `she/her` (unchanged)
* `["she", "they"]`: `she/them` -> `she/they`