### PR TITLE
fix(ItemPredicate): make reduce null safe

### DIFF
--- a/src/main/kotlin/me/owdding/skyblockpv/api/predicates/ItemPredicate.kt
+++ b/src/main/kotlin/me/owdding/skyblockpv/api/predicates/ItemPredicate.kt
@@ -19,7 +19,7 @@ object ItemPredicates {
     }
 
     fun AnySkyblockID(ids: List<String>): ItemPredicate {
-        return ids.map { SkyblockID(it) }.reduce(ItemPredicate::or)
+        return ids.map { SkyblockID(it) }.reduceOrNull(ItemPredicate::or) ?: of { false }
     }
 
 }


### PR DESCRIPTION
This is probably because of missing data, but I think it's better to be null-safe here anyway.

https://discord.com/channels/1296157888343179264/1296412068966305824/1497574567512899684