### PR TITLE
fix(Utils): mark executor pool threads daemon

### DIFF
--- a/src/main/kotlin/me/owdding/skyblockpv/utils/Utils.kt
+++ b/src/main/kotlin/me/owdding/skyblockpv/utils/Utils.kt
@@ -51,13 +51,19 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.jvm.optionals.getOrNull
 
 object Utils {
 
     var preferedProfileId: UUID? = null
 
-    val executorPool: ExecutorService = Executors.newFixedThreadPool(12)
+    val threadNumber = AtomicInteger(1)
+    val executorPool: ExecutorService = Executors.newFixedThreadPool(12) { runnable ->
+        Thread(runnable, "skyblockpv-executor-pool-thread-${threadNumber.getAndIncrement()}").apply {
+            isDaemon = true
+        }
+    }
 
     val onHypixel: Boolean get() = McClient.self.connection?.serverBrand()?.startsWith("Hypixel BungeeCord") == true
 


### PR DESCRIPTION
Client shutdown watchdog strikes again...

I also gave them unique identifiable names while I'm at it.